### PR TITLE
Fix eventConsole call in emailClickData and phoneClickData

### DIFF
--- a/ultimate-datalayer.liquid
+++ b/ultimate-datalayer.liquid
@@ -1023,7 +1023,7 @@
               }
 
               dataLayer.push(eventData);
-              this.eventConsole(self.eventPrefix + 'phone_number_click', eventData);
+              self.eventConsole(self.eventPrefix + 'phone_number_click', eventData);
             }
           });
         }
@@ -1044,7 +1044,7 @@
               }
 
               dataLayer.push(eventData);
-              this.eventConsole(self.eventPrefix + 'email_click', eventData);
+              self.eventConsole(self.eventPrefix + 'email_click', eventData);
             }
           });
         }


### PR DESCRIPTION
These changes fix the following errors in the `emailClickData` and `phoneClickData` methods when clicking on phone numbers and email addresses respectively:

```
Uncaught TypeError: this.eventConsole is not a function
```